### PR TITLE
Functions returning nol or nothing return NOL

### DIFF
--- a/nolang/astvisitors/interpreter.py
+++ b/nolang/astvisitors/interpreter.py
@@ -128,7 +128,7 @@ class Interpreter(ASTVisitor):
         stmt.expr.visit(self)
 
     def visit_return(self, stmt: ReturnStatement):
-        value = None
+        value = NOL # NOTE: Return NOL if there is no value!
         if stmt.has_value():
             value = stmt.value.visit(self)
 
@@ -164,7 +164,8 @@ class Interpreter(ASTVisitor):
         if arity != given:
             raise InvalidArgumentsException(expr.callee, arity, given, expr.paren.line, expr.paren.file_name)
 
-        return callee(self, args, expr.paren.line, expr.paren.file_name)
+        result = callee(self, args, expr.paren.line, expr.paren.file_name)
+        return result if result else NOL
 
     def visit_binexpr(self, expr: BinaryExpression):
         val1: NolangType = expr.left.visit(self)

--- a/nolang/runtime.py
+++ b/nolang/runtime.py
@@ -16,6 +16,7 @@ class Nolout(NolangCallable):
 
     def __call__(self, _, args: list[NolangType], *__):
         print(args[0])
+        return NOL
 
 class Nolin(NolangCallable):
     def arity(self) -> int:

--- a/supplemental/samples/return_nol.nl
+++ b/supplemental/samples/return_nol.nl
@@ -1,0 +1,11 @@
+
+greg foo()
+    nolout('foo')
+
+greg bar()
+    nolout('bar')
+    pay
+
+nolout(foo())
+nolout(bar())
+nolout(nolout('clock'))


### PR DESCRIPTION
```
greg foo()
    nolout('foo')

greg bar()
    nolout('bar')
    pay

nolout(foo())
nolout(bar())
nolout(nolout('clock'))
```
output:
```
foo
nol  
bar  
nol  
clock
nol
```